### PR TITLE
bump version and fix postgres pk problem with webhook entity

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,9 +30,9 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <main.java.package>io.phasetwo.keycloak.events</main.java.package>
     <junit.version>4.13.2</junit.version>
-    <keycloak.version>16.1.0</keycloak.version>
+    <keycloak.version>17.0.0</keycloak.version>
     <lombok.version>1.18.22</lombok.version>
-    <auto-service.version>1.0-rc7</auto-service.version>
+    <auto-service.version>1.0.1</auto-service.version>
     <ossrh.url>https://s01.oss.sonatype.org</ossrh.url>
   </properties>
 
@@ -69,7 +69,7 @@
 	  <transformers>
             <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
               <manifestEntries>
-		<Dependencies><![CDATA[org.keycloak.keycloak-common,org.keycloak.keycloak-core,org.keycloak.keycloak-server-spi,org.keycloak.keycloak-server-spi-private,org.apache.httpcomponents,org.keycloak.keycloak-services,org.jboss.logging,javax.api,javax.jms.api,javax.transaction.api,com.fasterxml.jackson.core.jackson-core,com.fasterxml.jackson.core.jackson-annotations,com.fasterxml.jackson.core.jackson-databind,com.google.guava]]></Dependencies>
+		<Dependencies><![CDATA[org.keycloak.keycloak-common,org.keycloak.keycloak-core,org.keycloak.keycloak-server-spi,org.keycloak.keycloak-server-spi-private,org.keycloak.keycloak-admin-client,org.apache.httpcomponents,org.keycloak.keycloak-services,org.jboss.logging,javax.api,javax.jms.api,javax.transaction.api,com.google.guava,com.fasterxml.jackson.core.jackson-core,com.fasterxml.jackson.core.jackson-annotations,com.fasterxml.jackson.core.jackson-databind,com.googlecode.owasp-java-html-sanitizer,org.apache.commons.io,org.bouncycastle,org.jboss.resteasy.resteasy-jaxrs]]></Dependencies>
               </manifestEntries>
             </transformer>
           </transformers>

--- a/src/main/resources/META-INF/jpa-changelog-events-20220311.xml
+++ b/src/main/resources/META-INF/jpa-changelog-events-20220311.xml
@@ -16,6 +16,7 @@
       <column name="CREATED_BY_USER_ID" type="VARCHAR(36)"/>
       <column name="REALM_ID" type="VARCHAR(36)"/>
     </createTable>
+    <addPrimaryKey columnNames="ID" constraintName="WEBHOOKPK" tableName="WEBHOOK"/>
     <createTable tableName="WEBHOOK_EVENT_TYPES">
       <column name="WEBHOOK_ID" type="VARCHAR(36)">
         <constraints nullable="false"/>


### PR DESCRIPTION
liquibase was failing migration due to 
```ALTER TABLE public.WEBHOOK_EVENT_TYPES ADD CONSTRAINT FK_H84RSK1GFRPJGWMN21UPW149J FOREIGN KEY (WEBHOOK_ID) REFERENCES public.WEBHOOK (ID)```
postres apparently requires fk constraints to reference primary or unique keys only. solved by adding primary key constraint to webhook table
```<addPrimaryKey columnNames="ID" constraintName="WEBHOOKPK" tableName="WEBHOOK"/>```