### PR TITLE
fix: add maven command

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This is currently known to work with Keycloak > 15.0.2. Other versions may work 
 
 ## Installation
 
-The maven build uses the shade plugin to package a fat-jar with all dependencies. Put the jar in your `providers` directory (for Quarkus) or `standalone/deployments` directory (for legacy) and rebuild/restart keycloak.
+The maven build can be triggered by running `mvn clean install`. It uses the shade plugin to package a fat-jar with all dependencies. Put the jar in your `providers` directory (for Quarkus) or `standalone/deployments` directory (for legacy) and rebuild/restart keycloak.
 
 ## Use
 


### PR DESCRIPTION
It'd be nice to mention the explicit mvn command that's needed to build the jar. You already do this in the [keycloak-themes](https://github.com/p2-inc/keycloak-themes) repo. So it seems in order to do it here, too.