### PR TITLE
Add UserModel getUser for AdminEvent

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ The script event listener allows you to run JS event listeners in the same fashi
 - `event`: the Event or AdminEvent
 - `realm`: the RealmModel
 - `user`: the UserModel (for `onEvent` only)
+- `authUser`: the UserModel (for `onAdminEvent` only)
 - `session`: the KeycloakSession
 - `LOG`: a JBoss Logger
 
@@ -68,7 +69,9 @@ function onAdminEvent(event, representation) {
       " on " +
       event.resourceType +
       " in realm " +
-      realm.name
+      realm.name +
+      " by user " +
+      authUser.username
   );
 }
 ```

--- a/src/main/java/io/phasetwo/keycloak/events/Events.java
+++ b/src/main/java/io/phasetwo/keycloak/events/Events.java
@@ -24,6 +24,13 @@ public class Events {
         : null;
   }
 
+  public static UserModel getUser(KeycloakSession session, AdminEvent event) {
+    RealmModel realm = getRealm(session, event);
+    return (event.getAuthDetails().getUserId() != null)
+        ? session.users().getUserById(realm, event.getAuthDetails().getUserId())
+        : null;
+  }
+
   public static String toString(Event event) {
     StringBuilder sb = new StringBuilder();
     sb.append("type=");

--- a/src/main/java/io/phasetwo/keycloak/events/Events.java
+++ b/src/main/java/io/phasetwo/keycloak/events/Events.java
@@ -24,7 +24,7 @@ public class Events {
         : null;
   }
 
-  public static UserModel getUser(KeycloakSession session, AdminEvent event) {
+  public static UserModel getAuthUser(KeycloakSession session, AdminEvent event) {
     RealmModel realm = getRealm(session, event);
     return (event.getAuthDetails().getUserId() != null)
         ? session.users().getUserById(realm, event.getAuthDetails().getUserId())

--- a/src/main/java/io/phasetwo/keycloak/events/ScriptEventListenerProvider.java
+++ b/src/main/java/io/phasetwo/keycloak/events/ScriptEventListenerProvider.java
@@ -66,7 +66,7 @@ public class ScriptEventListenerProvider implements EventListenerProvider, Confi
             bindings -> {
               bindings.put("event", event);
               bindings.put("realm", Events.getRealm(session, event));
-              bindings.put("user", Events.getUser(session, event));
+              bindings.put("authUser", Events.getAuthUser(session, event));
               bindings.put("session", session);
               bindings.put("LOG", log);
             });

--- a/src/main/java/io/phasetwo/keycloak/events/ScriptEventListenerProvider.java
+++ b/src/main/java/io/phasetwo/keycloak/events/ScriptEventListenerProvider.java
@@ -66,6 +66,7 @@ public class ScriptEventListenerProvider implements EventListenerProvider, Confi
             bindings -> {
               bindings.put("event", event);
               bindings.put("realm", Events.getRealm(session, event));
+              bindings.put("user", Events.getUser(session, event));
               bindings.put("session", session);
               bindings.put("LOG", log);
             });


### PR DESCRIPTION
Would be nice if the user object was available for the `AdminEvent` also so we could get the username and not only the userid 

Fixes https://github.com/p2-inc/keycloak-events/issues/48