### PR TITLE
add primary key to WEBHOOK_EVENT_TYPES table

### DIFF
--- a/src/main/resources/META-INF/jpa-changelog-events-20240417.xml
+++ b/src/main/resources/META-INF/jpa-changelog-events-20240417.xml
@@ -1,0 +1,6 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+  <changeSet author="garth (generated)" id="202404171144-1">
+    <addPrimaryKey columnNames="WEBHOOK_ID, VALUE" constraintName="WEBHOOK_EVENT_TYPES_PK" tableName="WEBHOOK_EVENT_TYPES"/>
+  </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/META-INF/jpa-changelog-events-main.xml
+++ b/src/main/resources/META-INF/jpa-changelog-events-main.xml
@@ -3,5 +3,6 @@
 
   <include file="META-INF/jpa-changelog-events-20220311.xml"/>
   <include file="META-INF/jpa-changelog-events-20221113.xml"/>
+  <include file="META-INF/jpa-changelog-events-20240417.xml"/>
 
 </databaseChangeLog>


### PR DESCRIPTION
The MySQL Mgr cluster requires that a unique primary key must exist in the table. Can a primary key be added when the table is initialized and created by keycloak?