### PR TITLE
#66 Use the original admin event authentication context to get realm

### DIFF
--- a/src/main/java/io/phasetwo/keycloak/events/WebhookSenderEventListenerProvider.java
+++ b/src/main/java/io/phasetwo/keycloak/events/WebhookSenderEventListenerProvider.java
@@ -157,7 +157,7 @@ public class WebhookSenderEventListenerProvider extends HttpSenderEventListenerP
   }
 
   private ExtendedAdminEvent completeAdminEventAttributes(String uid, AdminEvent adminEvent) {
-    RealmModel realm = session.realms().getRealm(adminEvent.getRealmId());
+    RealmModel realm = session.realms().getRealm(adminEvent.getAuthDetails().getRealmId());
     ExtendedAdminEvent extendedAdminEvent = new ExtendedAdminEvent(uid, adminEvent, realm);
     // add always missing agent username
     ExtendedAuthDetails extendedAuthDetails = extendedAdminEvent.getAuthDetails();
@@ -165,6 +165,7 @@ public class WebhookSenderEventListenerProvider extends HttpSenderEventListenerP
       UserModel user = session.users().getUserById(realm, extendedAuthDetails.getUserId());
       extendedAuthDetails.setUsername(user.getUsername());
     }
+
     // add username if resource is a user
     String resourcePath = extendedAdminEvent.getResourcePath();
     if (resourcePath != null && resourcePath.startsWith("users")) {


### PR DESCRIPTION
original extAuthDetails are null in ExtendedAdminEvent

logic here seems a bit wrong:
```
public ExtendedAdminEvent(String uid, AdminEvent event, RealmModel realm) {
 .....
    setAuthDetails(event.getAuthDetails());
    extAuthDetails.setRealmId(realm.getName());
....
}
```

we are basically overidding the realm of the original AuthDetails with the realm in which the event is triggered