### PR TITLE
Retrieve realm from correct field in admin events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ NOTES
 .factorypath
 .project
 .settings/
+bin

--- a/src/main/java/io/phasetwo/keycloak/events/WebhookSenderEventListenerProvider.java
+++ b/src/main/java/io/phasetwo/keycloak/events/WebhookSenderEventListenerProvider.java
@@ -157,7 +157,7 @@ public class WebhookSenderEventListenerProvider extends HttpSenderEventListenerP
   }
 
   private ExtendedAdminEvent completeAdminEventAttributes(String uid, AdminEvent adminEvent) {
-    RealmModel realm = session.realms().getRealm(adminEvent.getAuthDetails().getRealmId());
+    RealmModel realm = session.realms().getRealm(adminEvent.getRealmId());
     ExtendedAdminEvent extendedAdminEvent = new ExtendedAdminEvent(uid, adminEvent, realm);
     // add always missing agent username
     ExtendedAuthDetails extendedAuthDetails = extendedAdminEvent.getAuthDetails();

--- a/src/main/java/io/phasetwo/keycloak/events/WebhookSenderEventListenerProvider.java
+++ b/src/main/java/io/phasetwo/keycloak/events/WebhookSenderEventListenerProvider.java
@@ -157,12 +157,12 @@ public class WebhookSenderEventListenerProvider extends HttpSenderEventListenerP
   }
 
   private ExtendedAdminEvent completeAdminEventAttributes(String uid, AdminEvent adminEvent) {
-    RealmModel realm = session.realms().getRealm(adminEvent.getRealmId());
-    ExtendedAdminEvent extendedAdminEvent = new ExtendedAdminEvent(uid, adminEvent, realm);
+    RealmModel eventRealm = session.realms().getRealm(adminEvent.getRealmId());
+    RealmModel authRealm = session.realms().getRealm(adminEvent.getAuthDetails().getRealmId());
+    ExtendedAdminEvent extendedAdminEvent = new ExtendedAdminEvent(uid, adminEvent, eventRealm, authRealm);
     // add always missing agent username
     ExtendedAuthDetails extendedAuthDetails = extendedAdminEvent.getAuthDetails();
     if (!Strings.isNullOrEmpty(extendedAuthDetails.getUserId())) {
-      RealmModel authRealm = session.realms().getRealm(adminEvent.getAuthDetails().getRealmId());
       UserModel user = session.users().getUserById(authRealm, extendedAuthDetails.getUserId());
       extendedAuthDetails.setUsername(user.getUsername());
     }

--- a/src/main/java/io/phasetwo/keycloak/representation/ExtendedAdminEvent.java
+++ b/src/main/java/io/phasetwo/keycloak/representation/ExtendedAdminEvent.java
@@ -36,14 +36,14 @@ public class ExtendedAdminEvent extends AdminEvent {
 
   public ExtendedAdminEvent() {}
 
-  public ExtendedAdminEvent(String uid, AdminEvent event, RealmModel realm) {
+  public ExtendedAdminEvent(String uid, AdminEvent event, RealmModel eventRealm, RealmModel authRealm) {
     this.uid = uid;
     this.type = createType(event);
 
     setTime(event.getTime());
-    setRealmId(realm.getName());
+    setRealmId(eventRealm.getName());
     setAuthDetails(event.getAuthDetails());
-    extAuthDetails.setRealmId(realm.getName());
+    extAuthDetails.setRealmId(authRealm.getName());
     setResourceType(event.getResourceType());
     setResourceTypeAsString(event.getResourceTypeAsString());
     setOperationType(event.getOperationType());

--- a/src/test/java/io/phasetwo/keycloak/Helpers.java
+++ b/src/test/java/io/phasetwo/keycloak/Helpers.java
@@ -87,6 +87,20 @@ public class Helpers {
     return id;
   }
 
+  public static void removeWebhook(
+	      Keycloak keycloak,
+	      CloseableHttpClient httpClient,
+	      String baseUrl,
+	      String webhookId)
+	      throws Exception {
+
+	    LegacySimpleHttp.Response response =
+	        LegacySimpleHttp.doDelete(baseUrl + "/" + webhookId, httpClient)
+	            .auth(keycloak.tokenManager().getAccessTokenString())
+	            .asResponse();
+	    assertThat(response.getStatus(), is(204));
+	  }
+
   public static String urlencode(String u) {
     try {
       return URLEncoder.encode(u, "UTF-8");

--- a/src/test/java/io/phasetwo/keycloak/events/WebhookSenderEventListenerProviderTest.java
+++ b/src/test/java/io/phasetwo/keycloak/events/WebhookSenderEventListenerProviderTest.java
@@ -95,6 +95,23 @@ public class WebhookSenderEventListenerProviderTest extends AbstractResourceTest
 	    ExtendedAdminEvent event = parseEvent(receivedPayload);
 	    assertThat(event.getRealmId(), equalTo(REALM));
 	    assertThat(event.getAuthDetails().getRealmId(), equalTo(REALM));
+	    assertThat(event.getType(), equalTo("admin.USER-CREATE"));
+
+	    // Now delete the user
+	    List<UserRepresentation> users = realm.users().search("username");
+	    assertThat(users.size(), is(1));
+	    String userId = users.getFirst().getId();
+	    userResponse = realm.users().delete(userId);
+	    assertThat(userResponse.getStatus(), is(204));
+	    
+	    Thread.sleep(1000l);
+
+     	// check the handler for the event, after a delay
+	    receivedPayload = body.get();
+	    event = parseEvent(receivedPayload);
+	    assertThat(event.getRealmId(), equalTo(REALM));
+	    assertThat(event.getAuthDetails().getRealmId(), equalTo(REALM));
+	    assertThat(event.getType(), equalTo("admin.USER-DELETE"));
     }
     finally {
         server.stop();
@@ -158,6 +175,23 @@ public class WebhookSenderEventListenerProviderTest extends AbstractResourceTest
 	    ExtendedAdminEvent event = parseEvent(receivedPayload);
 	    assertThat(event.getRealmId(), equalTo(TEST_REALM));
 	    assertThat(event.getAuthDetails().getRealmId(), equalTo(REALM));
+	    assertThat(event.getType(), equalTo("admin.USER-CREATE"));
+
+	    // Now delete the user
+	    List<UserRepresentation> users = realm.users().search("username");
+	    assertThat(users.size(), is(1));
+	    String userId = users.getFirst().getId();
+	    userResponse = realm.users().delete(userId);
+	    assertThat(userResponse.getStatus(), is(204));
+	    
+	    Thread.sleep(1000l);
+
+     	// check the handler for the event, after a delay
+	    receivedPayload = body.get();
+	    event = parseEvent(receivedPayload);
+	    assertThat(event.getRealmId(), equalTo(TEST_REALM));
+	    assertThat(event.getAuthDetails().getRealmId(), equalTo(REALM));
+	    assertThat(event.getType(), equalTo("admin.USER-DELETE"));
 
 	    // cleanup
 	    realm.remove();
@@ -262,6 +296,23 @@ public class WebhookSenderEventListenerProviderTest extends AbstractResourceTest
 	    ExtendedAdminEvent event = parseEvent(receivedPayload);
 	    assertThat(event.getRealmId(), equalTo(TEST_REALM));
 	    assertThat(event.getAuthDetails().getRealmId(), equalTo(TEST_REALM));
+	    assertThat(event.getType(), equalTo("admin.USER-CREATE"));
+
+	    // Now delete the user
+	    List<UserRepresentation> users = realm.users().search("username");
+	    assertThat(users.size(), is(1));
+	    String userId = users.getFirst().getId();
+	    userResponse = realm.users().delete(userId);
+	    assertThat(userResponse.getStatus(), is(204));
+	    
+	    Thread.sleep(1000l);
+
+     	// check the handler for the event, after a delay
+	    receivedPayload = body.get();
+	    event = parseEvent(receivedPayload);
+	    assertThat(event.getRealmId(), equalTo(TEST_REALM));
+	    assertThat(event.getAuthDetails().getRealmId(), equalTo(TEST_REALM));
+	    assertThat(event.getType(), equalTo("admin.USER-DELETE"));
 
 	    // cleanup
 	    realm = keycloak.realm(TEST_REALM);

--- a/src/test/java/io/phasetwo/keycloak/events/WebhookSenderEventListenerProviderTest.java
+++ b/src/test/java/io/phasetwo/keycloak/events/WebhookSenderEventListenerProviderTest.java
@@ -1,19 +1,27 @@
 package io.phasetwo.keycloak.events;
 
 import static io.phasetwo.keycloak.Helpers.createWebhook;
+import static io.phasetwo.keycloak.Helpers.removeWebhook;
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.*;
 
 import java.util.Arrays;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
 
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.junit.jupiter.api.Test;
+import org.keycloak.OAuth2Constants;
+import org.keycloak.admin.client.Keycloak;
+import org.keycloak.admin.client.KeycloakBuilder;
 import org.keycloak.admin.client.resource.RealmResource;
-import org.keycloak.representations.idm.RealmRepresentation;
-import org.keycloak.representations.idm.UserRepresentation;
+import org.keycloak.representations.idm.ClientRepresentation;
 
+import org.keycloak.representations.idm.RealmRepresentation;
+import org.keycloak.representations.idm.RoleRepresentation;
+import org.keycloak.representations.idm.UserRepresentation;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.xgp.http.server.Server;
@@ -26,6 +34,7 @@ import lombok.extern.jbosslog.JBossLog;
 
 @JBossLog
 public class WebhookSenderEventListenerProviderTest extends AbstractResourceTest {
+  final static String TEST_REALM = "testRealm";
   CloseableHttpClient httpClient = HttpClients.createDefault();
 
   String webhookUrl(String realm) {
@@ -39,7 +48,7 @@ public class WebhookSenderEventListenerProviderTest extends AbstractResourceTest
   @Test
   public void testAdminEventContainsCorrectRealmMasterMaster() throws Exception {
     // Configure
-    RealmResource realm = keycloak.realm("master");
+    RealmResource realm = keycloak.realm(REALM);
     RealmRepresentation realmRepresentation = realm.toRepresentation();
     realmRepresentation.setAdminEventsEnabled(true);
     realmRepresentation.setAdminEventsDetailsEnabled(true);
@@ -49,10 +58,10 @@ public class WebhookSenderEventListenerProviderTest extends AbstractResourceTest
     AtomicReference<String> body = new AtomicReference<String>();
     // create a server on a free port with a handler to listen for the event
     int port = WEBHOOK_SERVER_PORT;
-    createWebhook(
+    String webhookId = createWebhook(
         keycloak,
         httpClient,
-        webhookUrl("master"),
+        webhookUrl(REALM),
         "http://host.testcontainers.internal:" + port + "/webhook",
         "qlfwemke",
         ImmutableSet.of("admin.*"));
@@ -84,18 +93,21 @@ public class WebhookSenderEventListenerProviderTest extends AbstractResourceTest
 	    // check the handler for the event, after a delay
 	    String receivedPayload = body.get();
 	    ExtendedAdminEvent event = parseEvent(receivedPayload);
-	    assertThat(event.getRealmId(), equalTo("master"));
-	    assertThat(event.getAuthDetails().getRealmId(), equalTo("master"));
+	    assertThat(event.getRealmId(), equalTo(REALM));
+	    assertThat(event.getAuthDetails().getRealmId(), equalTo(REALM));
     }
     finally {
         server.stop();
+        removeWebhook(keycloak,
+                httpClient,
+                webhookUrl(REALM),
+                webhookId);
     }
   }
 
   @Test
   public void testAdminEventContainsCorrectRealmMasterTest() throws Exception {
     // Create a realm for tests
-    final String TEST_REALM = "testRealm";
     RealmRepresentation realmRepresentation = new RealmRepresentation();
     realmRepresentation.setId(TEST_REALM);
     realmRepresentation.setDisplayName(TEST_REALM);
@@ -145,7 +157,115 @@ public class WebhookSenderEventListenerProviderTest extends AbstractResourceTest
 	    String receivedPayload = body.get();
 	    ExtendedAdminEvent event = parseEvent(receivedPayload);
 	    assertThat(event.getRealmId(), equalTo(TEST_REALM));
-	    assertThat(event.getAuthDetails().getRealmId(), equalTo("master"));
+	    assertThat(event.getAuthDetails().getRealmId(), equalTo(REALM));
+
+	    // cleanup
+	    realm.remove();
+    }
+    finally {
+        server.stop();
+    }
+  }
+
+  @Test
+  public void testAdminEventContainsCorrectRealmTestTest() throws Exception {
+    // Create a realm for tests
+    RealmRepresentation realmRepresentation = new RealmRepresentation();
+    realmRepresentation.setId(TEST_REALM);
+    realmRepresentation.setDisplayName(TEST_REALM);
+    realmRepresentation.setAdminEventsEnabled(true);
+    realmRepresentation.setAdminEventsDetailsEnabled(true);
+    realmRepresentation.setRealm(TEST_REALM);
+    realmRepresentation.setEventsListeners(Arrays.asList("ext-event-webhook"));
+    realmRepresentation.setEnabled(true);
+    keycloak.realms().create(realmRepresentation);
+    RealmResource realm = keycloak.realm(TEST_REALM);
+
+    // Creating admin client
+    final String realmAdminClientId = "realmAdmin";
+    final String realmAdminClientSecret = "realmPassword";
+    ClientRepresentation client = new ClientRepresentation();
+    client.setSecret(realmAdminClientSecret);
+    client.setClientId(realmAdminClientId);
+    client.setEnabled(true);
+    client.setServiceAccountsEnabled(true);
+    client.setPublicClient(false);
+    client.setProtocol("openid-connect");
+    Response clientCreationResponse = realm.clients().create(client);
+    assertThat(clientCreationResponse.getStatus(), is(201));
+
+    // Adding rights
+    String realmManagementId = realm.clients().findByClientId("realm-management").get(0).getId();
+    String clientId = realm.clients().findByClientId(realmAdminClientId).get(0).getId();
+    String serviceUserId = realm.clients().get(clientId).getServiceAccountUser().getId();
+    List<RoleRepresentation> availableRoles = realm
+            .users()
+            .get(serviceUserId)
+            .roles()
+            .clientLevel(realmManagementId)
+            .listAvailable();
+    List<RoleRepresentation> rolesToAssign = availableRoles
+            .stream()
+            .filter(r ->
+                "realm-admin".equalsIgnoreCase(r.getName()))
+            .collect(Collectors.toList());
+    assertThat(rolesToAssign.size(), is(1));
+    realm.users().get(serviceUserId).roles().clientLevel(realmManagementId).add(rolesToAssign);
+
+    AtomicReference<String> body = new AtomicReference<String>();
+    // create a server on a free port with a handler to listen for the event
+    int port = WEBHOOK_SERVER_PORT;
+    createWebhook(
+        keycloak,
+        httpClient,
+        webhookUrl(TEST_REALM),
+        "http://host.testcontainers.internal:" + port + "/webhook",
+        "qlfwemke",
+        ImmutableSet.of("admin.*"));
+
+    Server server = new Server(port);
+    server
+        .router()
+        .POST(
+            "/webhook",
+            (request, response) -> {
+              String r = request.body();
+              log.infof("%s", r);
+              body.set(r);
+              response.body("OK");
+              response.status(202);
+            });
+    server.start();
+    Thread.sleep(1000l);
+
+    try {
+        // log in to the test realm
+        Keycloak keycloakTestRealm = KeycloakBuilder.builder()
+                .serverUrl(getAuthUrl())
+                .clientId(realmAdminClientId)
+                .clientSecret(realmAdminClientSecret)
+                .realm(TEST_REALM)
+                .grantType(OAuth2Constants.CLIENT_CREDENTIALS)
+                .build();
+        realm = keycloakTestRealm.realm(TEST_REALM);
+
+	    // cause an event to be sent
+	    UserRepresentation userRepresentation = new UserRepresentation();
+	    userRepresentation.setUsername("username");
+	    Response userResponse = realm.users().create(userRepresentation);
+	    assertThat(userResponse.getStatus(), is(201));
+
+	    Thread.sleep(1000l);
+
+	    // check the handler for the event, after a delay
+	    String receivedPayload = body.get();
+	    ExtendedAdminEvent event = parseEvent(receivedPayload);
+	    assertThat(event.getRealmId(), equalTo(TEST_REALM));
+	    assertThat(event.getAuthDetails().getRealmId(), equalTo(TEST_REALM));
+
+	    // cleanup
+	    realm = keycloak.realm(TEST_REALM);
+	    realm.remove();
     }
     finally {
         server.stop();

--- a/src/test/java/io/phasetwo/keycloak/events/WebhookSenderEventListenerProviderTest.java
+++ b/src/test/java/io/phasetwo/keycloak/events/WebhookSenderEventListenerProviderTest.java
@@ -14,9 +14,12 @@ import org.keycloak.admin.client.resource.RealmResource;
 import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.xgp.http.server.Server;
 import com.google.common.collect.ImmutableSet;
 
+import io.phasetwo.keycloak.representation.ExtendedAdminEvent;
 import io.phasetwo.keycloak.resources.AbstractResourceTest;
 import jakarta.ws.rs.core.Response;
 import lombok.extern.jbosslog.JBossLog;
@@ -34,7 +37,63 @@ public class WebhookSenderEventListenerProviderTest extends AbstractResourceTest
   }
 
   @Test
-  public void testAdminEventContainsCorrectRealm() throws Exception {
+  public void testAdminEventContainsCorrectRealmMasterMaster() throws Exception {
+    // Configure
+    RealmResource realm = keycloak.realm("master");
+    RealmRepresentation realmRepresentation = realm.toRepresentation();
+    realmRepresentation.setAdminEventsEnabled(true);
+    realmRepresentation.setAdminEventsDetailsEnabled(true);
+    realmRepresentation.setEventsListeners(Arrays.asList("ext-event-webhook"));
+    realm.update(realmRepresentation);
+
+    AtomicReference<String> body = new AtomicReference<String>();
+    // create a server on a free port with a handler to listen for the event
+    int port = WEBHOOK_SERVER_PORT;
+    createWebhook(
+        keycloak,
+        httpClient,
+        webhookUrl("master"),
+        "http://host.testcontainers.internal:" + port + "/webhook",
+        "qlfwemke",
+        ImmutableSet.of("admin.*"));
+
+    Server server = new Server(port);
+    server
+        .router()
+        .POST(
+            "/webhook",
+            (request, response) -> {
+              String r = request.body();
+              log.infof("%s", r);
+              body.set(r);
+              response.body("OK");
+              response.status(202);
+            });
+    server.start();
+    Thread.sleep(1000l);
+
+    try {
+	    // cause an event to be sent
+	    UserRepresentation userRepresentation = new UserRepresentation();
+	    userRepresentation.setUsername("username");
+	    Response userResponse = realm.users().create(userRepresentation);
+	    assertThat(userResponse.getStatus(), is(201));
+
+	    Thread.sleep(1000l);
+
+	    // check the handler for the event, after a delay
+	    String receivedPayload = body.get();
+	    ExtendedAdminEvent event = parseEvent(receivedPayload);
+	    assertThat(event.getRealmId(), equalTo("master"));
+	    assertThat(event.getAuthDetails().getRealmId(), equalTo("master"));
+    }
+    finally {
+        server.stop();
+    }
+  }
+
+  @Test
+  public void testAdminEventContainsCorrectRealmMasterTest() throws Exception {
     // Create a realm for tests
     final String TEST_REALM = "testRealm";
     RealmRepresentation realmRepresentation = new RealmRepresentation();
@@ -73,20 +132,30 @@ public class WebhookSenderEventListenerProviderTest extends AbstractResourceTest
     server.start();
     Thread.sleep(1000l);
 
-    // cause an event to be sent
-    UserRepresentation userRepresentation = new UserRepresentation();
-    userRepresentation.setUsername("username");
-    Response userResponse = realm.users().create(userRepresentation);
-    assertThat(userResponse.getStatus(), is(201));
+    try {
+	    // cause an event to be sent
+	    UserRepresentation userRepresentation = new UserRepresentation();
+	    userRepresentation.setUsername("username");
+	    Response userResponse = realm.users().create(userRepresentation);
+	    assertThat(userResponse.getStatus(), is(201));
 
-    Thread.sleep(1000l);
+	    Thread.sleep(1000l);
 
-    // check the handler for the event, after a delay
-    String receivedPayload = body.get();
-    assertThat(receivedPayload, containsString(TEST_REALM));
-    assertThat(receivedPayload, not(containsString("master")));
+	    // check the handler for the event, after a delay
+	    String receivedPayload = body.get();
+	    ExtendedAdminEvent event = parseEvent(receivedPayload);
+	    assertThat(event.getRealmId(), equalTo(TEST_REALM));
+	    assertThat(event.getAuthDetails().getRealmId(), equalTo("master"));
+    }
+    finally {
+        server.stop();
+    }
+  }
 
-    server.stop();
-
+  private static ExtendedAdminEvent parseEvent(String input) throws Exception
+  {
+	  ObjectMapper mapper = new ObjectMapper();
+	  mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+	  return mapper.readValue(input, ExtendedAdminEvent.class);
   }
 }

--- a/src/test/java/io/phasetwo/keycloak/events/WebhookSenderEventListenerProviderTest.java
+++ b/src/test/java/io/phasetwo/keycloak/events/WebhookSenderEventListenerProviderTest.java
@@ -1,0 +1,92 @@
+package io.phasetwo.keycloak.events;
+
+import static io.phasetwo.keycloak.Helpers.createWebhook;
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.*;
+
+import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.junit.jupiter.api.Test;
+import org.keycloak.admin.client.resource.RealmResource;
+import org.keycloak.representations.idm.RealmRepresentation;
+import org.keycloak.representations.idm.UserRepresentation;
+
+import com.github.xgp.http.server.Server;
+import com.google.common.collect.ImmutableSet;
+
+import io.phasetwo.keycloak.resources.AbstractResourceTest;
+import jakarta.ws.rs.core.Response;
+import lombok.extern.jbosslog.JBossLog;
+
+@JBossLog
+public class WebhookSenderEventListenerProviderTest extends AbstractResourceTest {
+  CloseableHttpClient httpClient = HttpClients.createDefault();
+
+  String webhookUrl(String realm) {
+    return getAuthUrl() + "/realms/" + realm + "/webhooks";
+  }
+
+  String usersUrl(String realm) {
+    return getAuthUrl() + "/admin/realms/" + realm + "/users";
+  }
+
+  @Test
+  public void testAdminEventContainsCorrectRealm() throws Exception {
+    // Create a realm for tests
+    final String TEST_REALM = "testRealm";
+    RealmRepresentation realmRepresentation = new RealmRepresentation();
+    realmRepresentation.setId(TEST_REALM);
+    realmRepresentation.setDisplayName(TEST_REALM);
+    realmRepresentation.setAdminEventsEnabled(true);
+    realmRepresentation.setAdminEventsDetailsEnabled(true);
+    realmRepresentation.setRealm(TEST_REALM);
+    realmRepresentation.setEventsListeners(Arrays.asList("ext-event-webhook"));
+    keycloak.realms().create(realmRepresentation);
+    RealmResource realm = keycloak.realm(TEST_REALM);
+
+    AtomicReference<String> body = new AtomicReference<String>();
+    // create a server on a free port with a handler to listen for the event
+    int port = WEBHOOK_SERVER_PORT;
+    createWebhook(
+        keycloak,
+        httpClient,
+        webhookUrl(TEST_REALM),
+        "http://host.testcontainers.internal:" + port + "/webhook",
+        "qlfwemke",
+        ImmutableSet.of("admin.*"));
+
+    Server server = new Server(port);
+    server
+        .router()
+        .POST(
+            "/webhook",
+            (request, response) -> {
+              String r = request.body();
+              log.infof("%s", r);
+              body.set(r);
+              response.body("OK");
+              response.status(202);
+            });
+    server.start();
+    Thread.sleep(1000l);
+
+    // cause an event to be sent
+    UserRepresentation userRepresentation = new UserRepresentation();
+    userRepresentation.setUsername("username");
+    Response userResponse = realm.users().create(userRepresentation);
+    assertThat(userResponse.getStatus(), is(201));
+
+    Thread.sleep(1000l);
+
+    // check the handler for the event, after a delay
+    String receivedPayload = body.get();
+    assertThat(receivedPayload, containsString(TEST_REALM));
+    assertThat(receivedPayload, not(containsString("master")));
+
+    server.stop();
+
+  }
+}

--- a/src/test/java/io/phasetwo/keycloak/events/WebhookSenderEventListenerProviderTest.java
+++ b/src/test/java/io/phasetwo/keycloak/events/WebhookSenderEventListenerProviderTest.java
@@ -323,6 +323,129 @@ public class WebhookSenderEventListenerProviderTest extends AbstractResourceTest
     }
   }
 
+  @Test
+  public void testAdminEventContainsCorrectRealmCreatedByMaterRemovedByTest() throws Exception
+  {
+	    // Create a realm for tests
+	    RealmRepresentation realmRepresentation = new RealmRepresentation();
+	    realmRepresentation.setId(TEST_REALM);
+	    realmRepresentation.setDisplayName(TEST_REALM);
+	    realmRepresentation.setAdminEventsEnabled(true);
+	    realmRepresentation.setAdminEventsDetailsEnabled(true);
+	    realmRepresentation.setRealm(TEST_REALM);
+	    realmRepresentation.setEventsListeners(Arrays.asList("ext-event-webhook"));
+	    realmRepresentation.setEnabled(true);
+	    keycloak.realms().create(realmRepresentation);
+	    RealmResource realm = keycloak.realm(TEST_REALM);
+
+	    // Creating admin client
+	    final String realmAdminClientId = "realmAdmin";
+	    final String realmAdminClientSecret = "realmPassword";
+	    ClientRepresentation client = new ClientRepresentation();
+	    client.setSecret(realmAdminClientSecret);
+	    client.setClientId(realmAdminClientId);
+	    client.setEnabled(true);
+	    client.setServiceAccountsEnabled(true);
+	    client.setPublicClient(false);
+	    client.setProtocol("openid-connect");
+	    Response clientCreationResponse = realm.clients().create(client);
+	    assertThat(clientCreationResponse.getStatus(), is(201));
+
+	    // Adding rights
+	    String realmManagementId = realm.clients().findByClientId("realm-management").get(0).getId();
+	    String clientId = realm.clients().findByClientId(realmAdminClientId).get(0).getId();
+	    String serviceUserId = realm.clients().get(clientId).getServiceAccountUser().getId();
+	    List<RoleRepresentation> availableRoles = realm
+	            .users()
+	            .get(serviceUserId)
+	            .roles()
+	            .clientLevel(realmManagementId)
+	            .listAvailable();
+	    List<RoleRepresentation> rolesToAssign = availableRoles
+	            .stream()
+	            .filter(r ->
+	                "realm-admin".equalsIgnoreCase(r.getName()))
+	            .collect(Collectors.toList());
+	    assertThat(rolesToAssign.size(), is(1));
+	    realm.users().get(serviceUserId).roles().clientLevel(realmManagementId).add(rolesToAssign);
+
+	    AtomicReference<String> body = new AtomicReference<String>();
+	    // create a server on a free port with a handler to listen for the event
+	    int port = WEBHOOK_SERVER_PORT;
+	    createWebhook(
+	        keycloak,
+	        httpClient,
+	        webhookUrl(TEST_REALM),
+	        "http://host.testcontainers.internal:" + port + "/webhook",
+	        "qlfwemke",
+	        ImmutableSet.of("admin.*"));
+
+	    Server server = new Server(port);
+	    server
+	        .router()
+	        .POST(
+	            "/webhook",
+	            (request, response) -> {
+	              String r = request.body();
+	              log.infof("%s", r);
+	              body.set(r);
+	              response.body("OK");
+	              response.status(202);
+	            });
+	    server.start();
+	    Thread.sleep(1000l);
+
+	    try {
+		    // cause an event to be sent
+		    UserRepresentation userRepresentation = new UserRepresentation();
+		    userRepresentation.setUsername("username");
+		    Response userResponse = realm.users().create(userRepresentation);
+		    assertThat(userResponse.getStatus(), is(201));
+
+		    Thread.sleep(1000l);
+
+		    // check the handler for the event, after a delay
+		    String receivedPayload = body.get();
+		    ExtendedAdminEvent event = parseEvent(receivedPayload);
+		    assertThat(event.getRealmId(), equalTo(TEST_REALM));
+		    assertThat(event.getAuthDetails().getRealmId(), equalTo(REALM));
+		    assertThat(event.getType(), equalTo("admin.USER-CREATE"));
+
+	        // log in to the test realm
+	        Keycloak keycloakTestRealm = KeycloakBuilder.builder()
+	                .serverUrl(getAuthUrl())
+	                .clientId(realmAdminClientId)
+	                .clientSecret(realmAdminClientSecret)
+	                .realm(TEST_REALM)
+	                .grantType(OAuth2Constants.CLIENT_CREDENTIALS)
+	                .build();
+	        realm = keycloakTestRealm.realm(TEST_REALM);
+
+		    // Now delete the user
+		    List<UserRepresentation> users = realm.users().search("username");
+		    assertThat(users.size(), is(1));
+		    String userId = users.getFirst().getId();
+		    userResponse = realm.users().delete(userId);
+		    assertThat(userResponse.getStatus(), is(204));
+
+            Thread.sleep(1000l);
+
+            // check the handler for the event, after a delay
+		    receivedPayload = body.get();
+		    event = parseEvent(receivedPayload);
+		    assertThat(event.getRealmId(), equalTo(TEST_REALM));
+		    assertThat(event.getAuthDetails().getRealmId(), equalTo(TEST_REALM));
+		    assertThat(event.getType(), equalTo("admin.USER-DELETE"));
+
+		    // cleanup
+		    realm = keycloak.realm(TEST_REALM);
+		    realm.remove();
+	    }
+	    finally {
+	        server.stop();
+	    }
+  }
+
   private static ExtendedAdminEvent parseEvent(String input) throws Exception
   {
 	  ObjectMapper mapper = new ObjectMapper();


### PR DESCRIPTION
As discussed in in #71, this PR is fixing the remaining issues with realm IDs of admin events triggered from non-master Realms and provides an integration test.
