### PR TITLE
Fix service account admin webhook events

### DIFF
--- a/src/main/java/io/phasetwo/keycloak/events/WebhookSenderEventListenerProvider.java
+++ b/src/main/java/io/phasetwo/keycloak/events/WebhookSenderEventListenerProvider.java
@@ -329,7 +329,9 @@ public class WebhookSenderEventListenerProvider extends HttpSenderEventListenerP
     ExtendedAuthDetails extendedAuthDetails = extendedAdminEvent.getAuthDetails();
     if (!Strings.isNullOrEmpty(extendedAuthDetails.getUserId())) {
       UserModel user = session.users().getUserById(authRealm, extendedAuthDetails.getUserId());
-      extendedAuthDetails.setUsername(user.getUsername());
+      if (user != null) {
+        extendedAuthDetails.setUsername(user.getUsername());
+      }
     }
 
     // add username if resource is a user


### PR DESCRIPTION
Fix webhook admin events triggered by service accounts.

When a service account triggers an admin event, Keycloak can provide an auth user ID that cannot be resolved to a `UserModel`. The listener then failed with a `NullPointerException` while trying to read `user.getUsername()`.

This change makes username enrichment optional. If the user is found, the username is added as before. If not, the webhook event is still sent with the available auth details like `clientId`, `userId`, realm and IP address.