### PR TITLE
Add JWT bearer authentication for webhooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,9 @@ The webhook object has this format:
   "enabled": "true",
   "url": "https://example.com/some/webhook",
   "secret": "ofj09saP4",
+  "authType": "hmac",
+  "algorithm": "HmacSHA256",
+  "audience": null,
   "eventTypes": ["*"],
   "createdBy": "ff730b72-a421-4f6e-9e4e-7fc7f53bac88",
   "createdAt": "2021-04-21T18:25:43-05:00"
@@ -282,6 +285,39 @@ The webhook object has this format:
 ```
 
 For creating and updating of webhooks, `id`, `createdBy` and `createdAt` are ignored. `secret` is not sent when fetching webhooks.
+
+#### Authenticating the webhook payload
+
+Each webhook may authenticate its payload one of two ways, selected by the `authType` field:
+
+| `authType` | Header | How the receiver verifies |
+| --- | --- | --- |
+| `hmac` (default) | `X-Keycloak-Signature` | Recompute the keyed-HMAC of the raw request body using the shared `secret` and compare. |
+| `bearer` | `Authorization: Bearer <jwt>` | Verify a short-lived JWT signed by the realm's active signing key against the realm's JWKS. No shared secret is required. |
+
+**HMAC (shared secret).** Set `secret` (and optionally `algorithm`, defaulting to `HmacSHA256`, or `HmacSHA1` for backwards compatibility). The RFC2104 signature of the request body is sent in the `X-Keycloak-Signature` header. This is the default and is unchanged from previous versions — webhooks created without an `authType` continue to behave exactly as before.
+
+**Bearer JWT (asymmetric, no shared secret).** Set `authType` to `bearer` and provide an `audience`. On each send a fresh JWT is minted, signed with the realm's active signing key (`algorithm` defaults to `RS256`), and sent in the `Authorization: Bearer` header. The receiver validates it against the realm's published keys — the same keys used for access tokens — so no secret needs to be exchanged or stored:
+
+```json
+{
+  "jwks_uri": "https://keycloak.example.com/realms/my-realm/protocol/openid-connect/certs",
+  "issuer": "https://keycloak.example.com/realms/my-realm",
+  "audience": "https://receiver.example.com"
+}
+```
+
+The token carries these claims:
+
+| Claim | Value |
+| --- | --- |
+| `iss` | The realm issuer, e.g. `https://keycloak.example.com/realms/my-realm` |
+| `aud` | The configured `audience` |
+| `iat` / `exp` | Issued-at and expiry. Lifespan defaults to 300s; override with the `WEBHOOK_JWT_LIFESPAN_SECONDS` env var. A fresh token is minted for every send attempt, including retries. |
+| `jti` | A unique token id |
+| `request_body_sha256` | Hex-encoded SHA-256 of the exact request body, binding the token to the payload so it cannot be replayed against a different body. |
+
+The token issuer is resolved, in order, from: the realm's configured frontend URL, the `KC_HOSTNAME` environment variable, and finally the base URI of the request that produced the event. For the issuer to match the realm's real token issuer in production (where webhooks are dispatched on a background thread with no request context), configure the realm frontend URL or `KC_HOSTNAME`.
 
 #### SPI configuration
 
@@ -373,6 +409,8 @@ It is possible to disable the scripts run by the `ScriptEventListenerProvider` b
 
 #### Webhooks
 There is a special catch-all webhook that can be used by system owners to always send events to an endpoint, even though it is not defined as a manageable webhook entity. Set the `WEBHOOK_URI` AND `WEBHOOK_SECRET` environment variables, and all events will be sent to this endpoint. This is used, for example, in cases where system owners want to send events to a more scalable store.
+
+The catch-all webhook can also authenticate with a bearer JWT instead of an HMAC shared secret (see [Authenticating the webhook payload](#authenticating-the-webhook-payload)). Set `WEBHOOK_AUTH_TYPE=bearer` and `WEBHOOK_AUDIENCE=<audience>`; `WEBHOOK_ALGORITHM` selects the JWS algorithm (defaults to `RS256`).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -288,14 +288,19 @@ For creating and updating of webhooks, `id`, `createdBy` and `createdAt` are ign
 
 #### Authenticating the webhook payload
 
-Each webhook may authenticate its payload one of two ways, selected by the `authType` field:
+Each webhook authenticates its payload one of three ways, selected by the `authType` field:
 
 | `authType` | Header | How the receiver verifies |
 | --- | --- | --- |
-| `hmac` (default) | `X-Keycloak-Signature` | Recompute the keyed-HMAC of the raw request body using the shared `secret` and compare. |
+| `none` | — | The payload is sent unauthenticated. |
+| `hmac` | `X-Keycloak-Signature` | Recompute the keyed-HMAC of the raw request body using the shared `secret` and compare. |
 | `bearer` | `Authorization: Bearer <jwt>` | Verify a short-lived JWT signed by the realm's active signing key against the realm's JWKS. No shared secret is required. |
 
-**HMAC (shared secret).** Set `secret` (and optionally `algorithm`, defaulting to `HmacSHA256`, or `HmacSHA1` for backwards compatibility). The RFC2104 signature of the request body is sent in the `X-Keycloak-Signature` header. This is the default and is unchanged from previous versions — webhooks created without an `authType` continue to behave exactly as before.
+When `authType` is omitted, the historical behavior is preserved: a webhook with a `secret` defaults to `hmac`, and one without a secret defaults to `none`. Existing webhooks are therefore unchanged.
+
+**None.** Set `authType` to `none` (or simply omit both `authType` and `secret`) to send the payload without any signature or token.
+
+**HMAC (shared secret).** Set `authType` to `hmac` and provide a `secret` (and optionally `algorithm`, defaulting to `HmacSHA256`, or `HmacSHA1` for backwards compatibility). The RFC2104 signature of the request body is sent in the `X-Keycloak-Signature` header.
 
 **Bearer JWT (asymmetric, no shared secret).** Set `authType` to `bearer` and provide an `audience`. On each send a fresh JWT is minted, signed with the realm's active signing key (`algorithm` defaults to `RS256`), and sent in the `Authorization: Bearer` header. The receiver validates it against the realm's published keys — the same keys used for access tokens — so no secret needs to be exchanged or stored:
 

--- a/src/main/java/io/phasetwo/keycloak/events/HttpSenderEventListenerProvider.java
+++ b/src/main/java/io/phasetwo/keycloak/events/HttpSenderEventListenerProvider.java
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.security.SignatureException;
 import java.util.Optional;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.function.Consumer;
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
 import lombok.extern.jbosslog.JBossLog;
@@ -70,15 +71,31 @@ public class HttpSenderEventListenerProvider extends SenderEventListenerProvider
   protected void send(
       SenderTask task, String targetUri, Optional<String> sharedSecret, Optional<String> algorithm)
       throws SenderException, IOException {
+    send(
+        task,
+        targetUri,
+        request ->
+            sharedSecret.ifPresent(
+                secret ->
+                    request.header(
+                        "X-Keycloak-Signature",
+                        hmacFor(
+                            task.getEvent(), secret, algorithm.orElse(HMAC_SHA256_ALGORITHM)))));
+  }
+
+  /**
+   * Send the payload, applying an arbitrary authentication decorator (e.g. an HMAC signature header
+   * or an {@code Authorization: Bearer} JWT) to the request before it is sent.
+   */
+  protected void send(SenderTask task, String targetUri, Consumer<LegacySimpleHttp> authDecorator)
+      throws SenderException, IOException {
     task.incrementAndGetAttempt();
     log.debugf("attempting send to %s", targetUri);
     try (CloseableHttpClient http = HttpClients.createDefault()) {
       LegacySimpleHttp request = LegacySimpleHttp.doPost(targetUri, http).json(task.getEvent());
-      sharedSecret.ifPresent(
-          secret ->
-              request.header(
-                  "X-Keycloak-Signature",
-                  hmacFor(task.getEvent(), secret, algorithm.orElse(HMAC_SHA256_ALGORITHM))));
+      if (authDecorator != null) {
+        authDecorator.accept(request);
+      }
       LegacySimpleHttp.Response response = request.asResponse();
       int status = response.getStatus();
       log.debugf("sent to %s (%d)", targetUri, status);

--- a/src/main/java/io/phasetwo/keycloak/events/WebhookJwtSigner.java
+++ b/src/main/java/io/phasetwo/keycloak/events/WebhookJwtSigner.java
@@ -1,0 +1,147 @@
+package io.phasetwo.keycloak.events;
+
+import com.google.common.base.Strings;
+import io.phasetwo.keycloak.model.WebhookModel;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import lombok.extern.jbosslog.JBossLog;
+import org.keycloak.common.util.Time;
+import org.keycloak.crypto.KeyUse;
+import org.keycloak.crypto.KeyWrapper;
+import org.keycloak.crypto.SignatureProvider;
+import org.keycloak.crypto.SignatureSignerContext;
+import org.keycloak.jose.jws.JWSBuilder;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.utils.KeycloakModelUtils;
+import org.keycloak.representations.JsonWebToken;
+import org.keycloak.services.Urls;
+
+/**
+ * Mints a short-lived JWT signed with the realm's active signing key so a webhook receiver can
+ * authenticate the payload against the realm's JWKS endpoint (issuer + audience) without a shared
+ * secret.
+ *
+ * <p>The token carries a {@code request_body_sha256} claim binding it to the exact payload, so it
+ * cannot be replayed against a different body.
+ */
+@JBossLog
+public final class WebhookJwtSigner {
+
+  /** Realm attribute holding an explicitly configured frontend URL. */
+  static final String FRONTEND_URL_ATTRIBUTE = "frontendUrl";
+
+  /** Environment variable holding the Keycloak hostname/base URL. */
+  static final String KC_HOSTNAME_ENV = "KC_HOSTNAME";
+
+  /** Claim binding the token to the exact request body. */
+  static final String BODY_HASH_CLAIM = "request_body_sha256";
+
+  /** Default token lifespan in seconds; overridable via {@code WEBHOOK_JWT_LIFESPAN_SECONDS}. */
+  static final int DEFAULT_LIFESPAN_SECONDS = 300;
+
+  private static final String LIFESPAN_ENV = "WEBHOOK_JWT_LIFESPAN_SECONDS";
+
+  private WebhookJwtSigner() {}
+
+  /**
+   * Sign a bearer JWT for the given realm and payload.
+   *
+   * @param session a live session (needed for realm signing keys)
+   * @param realm the realm whose active key signs the token and whose issuer it carries
+   * @param algorithm the JWS algorithm (e.g. {@code RS256}); defaults to {@link
+   *     WebhookModel#DEFAULT_BEARER_ALGORITHM} when blank
+   * @param audience the {@code aud} claim; may be null
+   * @param body the exact serialized request body, hashed into the {@code request_body_sha256} claim
+   * @param fallbackBaseUri base URI to derive the issuer from when neither the realm frontend URL
+   *     nor {@code KC_HOSTNAME} is set; may be null
+   * @return the signed compact JWS, or null if it could not be produced
+   */
+  public static String sign(
+      KeycloakSession session,
+      RealmModel realm,
+      String algorithm,
+      String audience,
+      String body,
+      String fallbackBaseUri) {
+    try {
+      String alg =
+          Strings.isNullOrEmpty(algorithm) ? WebhookModel.DEFAULT_BEARER_ALGORITHM : algorithm;
+
+      KeyWrapper key = session.keys().getActiveKey(realm, KeyUse.SIG, alg);
+      if (key == null) {
+        log.warnf(
+            "No active %s signing key for realm %s; cannot sign webhook JWT", alg, realm.getName());
+        return null;
+      }
+      SignatureSignerContext signer = session.getProvider(SignatureProvider.class, alg).signer(key);
+
+      int now = Time.currentTime();
+      JsonWebToken token = new JsonWebToken();
+      token.id(KeycloakModelUtils.generateId());
+      token.issuer(resolveIssuer(realm, fallbackBaseUri));
+      if (!Strings.isNullOrEmpty(audience)) {
+        token.audience(audience);
+      }
+      token.iat((long) now);
+      token.exp((long) (now + lifespanSeconds()));
+      token.setOtherClaims(BODY_HASH_CLAIM, sha256Hex(body));
+
+      return new JWSBuilder().type("JWT").kid(key.getKid()).jsonContent(token).sign(signer);
+    } catch (Exception e) {
+      log.warn("Unable to sign webhook JWT", e);
+      return null;
+    }
+  }
+
+  /**
+   * Resolve the token issuer the same way Keycloak resolves realm token issuers: prefer the realm's
+   * configured frontend URL, then {@code KC_HOSTNAME}, then the supplied request base URI.
+   */
+  static String resolveIssuer(RealmModel realm, String fallbackBaseUri) {
+    String base = realm.getAttribute(FRONTEND_URL_ATTRIBUTE);
+    if (Strings.isNullOrEmpty(base)) {
+      base = System.getenv(KC_HOSTNAME_ENV);
+    }
+    if (Strings.isNullOrEmpty(base)) {
+      base = fallbackBaseUri;
+    }
+    if (Strings.isNullOrEmpty(base)) {
+      // last resort: an opaque but stable issuer derived from the realm name
+      return Urls.realmIssuer(URI.create("https://localhost/"), realm.getName());
+    }
+    if (!base.startsWith("http://") && !base.startsWith("https://")) {
+      base = "https://" + base;
+    }
+    if (!base.endsWith("/")) {
+      base = base + "/";
+    }
+    return Urls.realmIssuer(URI.create(base), realm.getName());
+  }
+
+  private static int lifespanSeconds() {
+    String v = System.getenv(LIFESPAN_ENV);
+    if (!Strings.isNullOrEmpty(v)) {
+      try {
+        int parsed = Integer.parseInt(v.trim());
+        if (parsed > 0) return parsed;
+      } catch (NumberFormatException e) {
+        log.warnf("Invalid %s=%s; using default %d", LIFESPAN_ENV, v, DEFAULT_LIFESPAN_SECONDS);
+      }
+    }
+    return DEFAULT_LIFESPAN_SECONDS;
+  }
+
+  static String sha256Hex(String data) throws Exception {
+    MessageDigest md = MessageDigest.getInstance("SHA-256");
+    byte[] digest = md.digest(data.getBytes(StandardCharsets.UTF_8));
+    StringBuilder sb = new StringBuilder(digest.length * 2);
+    for (byte b : digest) {
+      String s = Integer.toHexString(0xFF & b);
+      if (s.length() == 1) sb.append('0');
+      sb.append(s);
+    }
+    return sb.toString();
+  }
+}

--- a/src/main/java/io/phasetwo/keycloak/events/WebhookSenderEventListenerProvider.java
+++ b/src/main/java/io/phasetwo/keycloak/events/WebhookSenderEventListenerProvider.java
@@ -14,6 +14,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -35,6 +36,8 @@ public class WebhookSenderEventListenerProvider extends HttpSenderEventListenerP
   private static final String WEBHOOK_URI_ENV = "WEBHOOK_URI";
   private static final String WEBHOOK_SECRET_ENV = "WEBHOOK_SECRET";
   private static final String WEBHOOK_ALGORITHM_ENV = "WEBHOOK_ALGORITHM";
+  private static final String WEBHOOK_AUTH_TYPE_ENV = "WEBHOOK_AUTH_TYPE";
+  private static final String WEBHOOK_AUDIENCE_ENV = "WEBHOOK_AUDIENCE";
 
   public static final String WEBHOOK_SEND_LOGGER_NAME = "io.phasetwo.keycloak.WEBHOOK_SEND_LOGGER";
   public static final String MDC_KEY_PREFIX = "webhook.";
@@ -51,6 +54,12 @@ public class WebhookSenderEventListenerProvider extends HttpSenderEventListenerP
   private final String systemUri;
   private final String systemSecret;
   private final String systemAlgorithm;
+  private final String systemAuthType;
+  private final String systemAudience;
+
+  // request base URI captured at construction (request thread has context); used as a fallback for
+  // deriving the JWT issuer when signing later on a background thread with no request context.
+  private final String contextBaseUri;
 
   public WebhookSenderEventListenerProvider(
       KeycloakSession session, ScheduledExecutorService exec, WebhookSenderConfig config) {
@@ -62,8 +71,20 @@ public class WebhookSenderEventListenerProvider extends HttpSenderEventListenerP
     this.systemUri = System.getenv(WEBHOOK_URI_ENV);
     this.systemSecret = System.getenv(WEBHOOK_SECRET_ENV);
     this.systemAlgorithm = System.getenv(WEBHOOK_ALGORITHM_ENV);
+    this.systemAuthType = System.getenv(WEBHOOK_AUTH_TYPE_ENV);
+    this.systemAudience = System.getenv(WEBHOOK_AUDIENCE_ENV);
+    this.contextBaseUri = captureBaseUri(session);
     this.config = config;
     this.webhooks = session.getProvider(WebhookProvider.class);
+  }
+
+  private static String captureBaseUri(KeycloakSession session) {
+    try {
+      return session.getContext().getUri().getBaseUri().toString();
+    } catch (Exception e) {
+      log.tracef("couldn't capture request base URI: %s", e.getMessage());
+      return null;
+    }
   }
 
   @Override
@@ -168,7 +189,14 @@ public class WebhookSenderEventListenerProvider extends HttpSenderEventListenerP
           if (!Strings.isNullOrEmpty(systemUri)) {
             ExtendedAdminEvent customEvent = clone(event);
             customEvent.setUid(KeycloakModelUtils.generateId());
-            schedule(null, customEvent, systemUri, systemSecret, systemAlgorithm);
+            schedule(
+                null,
+                customEvent,
+                systemUri,
+                systemSecret,
+                systemAlgorithm,
+                systemAuthType,
+                systemAudience);
           }
         });
   }
@@ -263,7 +291,9 @@ public class WebhookSenderEventListenerProvider extends HttpSenderEventListenerP
         customEvent,
         webhook.getUrl(),
         webhook.getSecret(),
-        webhook.getAlgorithm());
+        webhook.getAlgorithm(),
+        webhook.getAuthType(),
+        webhook.getAudience());
   }
 
   private void schedule(
@@ -271,12 +301,19 @@ public class WebhookSenderEventListenerProvider extends HttpSenderEventListenerP
       ExtendedAdminEvent customEvent,
       String url,
       String secret,
-      String algorithm) {
+      String algorithm,
+      String authType,
+      String audience) {
     SenderTask task = new SenderTask(customEvent, getBackOff());
     task.getProperties().put("webhookId", webhookId);
     task.getProperties().put("url", url);
-    task.getProperties().put("secret", secret);
-    task.getProperties().put("algorithm", algorithm);
+    if (secret != null) task.getProperties().put("secret", secret);
+    if (algorithm != null) task.getProperties().put("algorithm", algorithm);
+    if (authType != null) task.getProperties().put("authType", authType);
+    if (audience != null) task.getProperties().put("audience", audience);
+    if (customEvent.getRealmId() != null) {
+      task.getProperties().put("realmId", customEvent.getRealmId());
+    }
     schedule(task, 0l, TimeUnit.MILLISECONDS);
   }
 
@@ -301,9 +338,53 @@ public class WebhookSenderEventListenerProvider extends HttpSenderEventListenerP
   @Override
   void send(SenderTask task) throws SenderException, IOException {
     String targetUri = task.getProperties().get("url");
-    Optional<String> sharedSecret = Optional.ofNullable(task.getProperties().get("secret"));
-    Optional<String> hmacAlgorithm = Optional.ofNullable(task.getProperties().get("algorithm"));
-    send(task, targetUri, sharedSecret, hmacAlgorithm);
+    String authType = task.getProperties().get("authType");
+    if (WebhookModel.AUTH_TYPE_BEARER.equalsIgnoreCase(authType)) {
+      String bearer = generateBearerToken(task);
+      send(
+          task,
+          targetUri,
+          request -> {
+            if (bearer != null) request.header("Authorization", "Bearer " + bearer);
+          });
+    } else {
+      Optional<String> sharedSecret = Optional.ofNullable(task.getProperties().get("secret"));
+      Optional<String> hmacAlgorithm = Optional.ofNullable(task.getProperties().get("algorithm"));
+      send(task, targetUri, sharedSecret, hmacAlgorithm);
+    }
+  }
+
+  /**
+   * Mint a fresh realm-signed JWT for this send attempt. Runs in its own transaction because {@code
+   * send} executes on a background scheduler thread with no live request session, and signing needs
+   * the realm's active signing key.
+   */
+  private String generateBearerToken(SenderTask task) {
+    String realmId = task.getProperties().get("realmId");
+    if (Strings.isNullOrEmpty(realmId)) {
+      log.warn("Cannot generate webhook bearer token: missing realmId");
+      return null;
+    }
+    String algorithm = task.getProperties().get("algorithm");
+    String audience = task.getProperties().get("audience");
+    final AtomicReference<String> token = new AtomicReference<>();
+    try {
+      final String body = JsonSerialization.writeValueAsString(task.getEvent());
+      KeycloakModelUtils.runJobInTransaction(
+          factory,
+          (session) -> {
+            RealmModel realm = session.realms().getRealm(realmId);
+            if (realm == null) {
+              log.warnf("Cannot generate webhook bearer token: realm %s not found", realmId);
+              return;
+            }
+            token.set(
+                WebhookJwtSigner.sign(session, realm, algorithm, audience, body, contextBaseUri));
+          });
+    } catch (Exception e) {
+      log.warn("Error generating webhook bearer token", e);
+    }
+    return token.get();
   }
 
   private ExtendedAdminEvent completeAdminEventAttributes(String uid, Event event) {

--- a/src/main/java/io/phasetwo/keycloak/events/WebhookSenderEventListenerProvider.java
+++ b/src/main/java/io/phasetwo/keycloak/events/WebhookSenderEventListenerProvider.java
@@ -347,7 +347,11 @@ public class WebhookSenderEventListenerProvider extends HttpSenderEventListenerP
           request -> {
             if (bearer != null) request.header("Authorization", "Bearer " + bearer);
           });
+    } else if (WebhookModel.AUTH_TYPE_NONE.equalsIgnoreCase(authType)) {
+      // explicitly unauthenticated: never attach a signature, even if a secret is present
+      send(task, targetUri, Optional.empty(), Optional.empty());
     } else {
+      // hmac (or a legacy webhook with no authType): sign only when a secret is present
       Optional<String> sharedSecret = Optional.ofNullable(task.getProperties().get("secret"));
       Optional<String> hmacAlgorithm = Optional.ofNullable(task.getProperties().get("algorithm"));
       send(task, targetUri, sharedSecret, hmacAlgorithm);

--- a/src/main/java/io/phasetwo/keycloak/model/WebhookModel.java
+++ b/src/main/java/io/phasetwo/keycloak/model/WebhookModel.java
@@ -7,6 +7,21 @@ import org.keycloak.models.UserModel;
 
 public interface WebhookModel {
 
+  /** HMAC signature of the payload sent in the {@code X-Keycloak-Signature} header (default). */
+  String AUTH_TYPE_HMAC = "hmac";
+
+  /**
+   * A short-lived JWT signed by the realm's active signing key, sent in the {@code Authorization:
+   * Bearer} header and verifiable against the realm's JWKS endpoint.
+   */
+  String AUTH_TYPE_BEARER = "bearer";
+
+  /** Default JWS algorithm used when {@link #getAuthType()} is {@link #AUTH_TYPE_BEARER}. */
+  String DEFAULT_BEARER_ALGORITHM = "RS256";
+
+  /** Default HMAC algorithm used when {@link #getAuthType()} is {@link #AUTH_TYPE_HMAC}. */
+  String DEFAULT_HMAC_ALGORITHM = "HmacSHA256";
+
   String getId();
 
   boolean isEnabled();
@@ -24,6 +39,14 @@ public interface WebhookModel {
   String getAlgorithm();
 
   void setAlgorithm(String algorithm);
+
+  String getAuthType();
+
+  void setAuthType(String authType);
+
+  String getAudience();
+
+  void setAudience(String audience);
 
   RealmModel getRealm();
 

--- a/src/main/java/io/phasetwo/keycloak/model/WebhookModel.java
+++ b/src/main/java/io/phasetwo/keycloak/model/WebhookModel.java
@@ -7,7 +7,10 @@ import org.keycloak.models.UserModel;
 
 public interface WebhookModel {
 
-  /** HMAC signature of the payload sent in the {@code X-Keycloak-Signature} header (default). */
+  /** No authentication: the payload is sent without a signature or bearer token. */
+  String AUTH_TYPE_NONE = "none";
+
+  /** HMAC signature of the payload sent in the {@code X-Keycloak-Signature} header. */
   String AUTH_TYPE_HMAC = "hmac";
 
   /**

--- a/src/main/java/io/phasetwo/keycloak/model/jpa/WebhookAdapter.java
+++ b/src/main/java/io/phasetwo/keycloak/model/jpa/WebhookAdapter.java
@@ -76,6 +76,26 @@ public class WebhookAdapter implements WebhookModel, JpaModel<WebhookEntity> {
   }
 
   @Override
+  public String getAuthType() {
+    return webhook.getAuthType();
+  }
+
+  @Override
+  public void setAuthType(String authType) {
+    webhook.setAuthType(authType);
+  }
+
+  @Override
+  public String getAudience() {
+    return webhook.getAudience();
+  }
+
+  @Override
+  public void setAudience(String audience) {
+    webhook.setAudience(audience);
+  }
+
+  @Override
   public RealmModel getRealm() {
     return session.realms().getRealm(webhook.getRealmId());
   }

--- a/src/main/java/io/phasetwo/keycloak/model/jpa/entity/WebhookEntity.java
+++ b/src/main/java/io/phasetwo/keycloak/model/jpa/entity/WebhookEntity.java
@@ -1,6 +1,20 @@
 package io.phasetwo.keycloak.model.jpa.entity;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Access;
+import jakarta.persistence.AccessType;
+import jakarta.persistence.CollectionTable;
+import jakarta.persistence.Column;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.NamedQueries;
+import jakarta.persistence.NamedQuery;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import jakarta.persistence.Temporal;
+import jakarta.persistence.TemporalType;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.Set;
@@ -38,6 +52,12 @@ public class WebhookEntity {
 
   @Column(name = "ALGORITHM")
   protected String algorithm;
+
+  @Column(name = "AUTH_TYPE")
+  protected String authType;
+
+  @Column(name = "AUDIENCE")
+  protected String audience;
 
   @ElementCollection(fetch = FetchType.EAGER)
   @Column(name = "VALUE")
@@ -104,6 +124,22 @@ public class WebhookEntity {
 
   public void setAlgorithm(String algorithm) {
     this.algorithm = algorithm;
+  }
+
+  public String getAuthType() {
+    return authType;
+  }
+
+  public void setAuthType(String authType) {
+    this.authType = authType;
+  }
+
+  public String getAudience() {
+    return audience;
+  }
+
+  public void setAudience(String audience) {
+    this.audience = audience;
   }
 
   public Set<String> getEventTypes() {

--- a/src/main/java/io/phasetwo/keycloak/representation/WebhookRepresentation.java
+++ b/src/main/java/io/phasetwo/keycloak/representation/WebhookRepresentation.java
@@ -11,6 +11,8 @@ public class WebhookRepresentation {
   private String url;
   private String secret;
   private String algorithm;
+  private String authType;
+  private String audience;
   private String createdBy;
   private Date createdAt;
   private String realm;

--- a/src/main/java/io/phasetwo/keycloak/resources/WebhooksResource.java
+++ b/src/main/java/io/phasetwo/keycloak/resources/WebhooksResource.java
@@ -10,15 +10,17 @@ import io.phasetwo.keycloak.representation.Credential;
 import io.phasetwo.keycloak.representation.ExtendedAdminEvent;
 import io.phasetwo.keycloak.representation.WebhookRepresentation;
 import io.phasetwo.keycloak.representation.WebhookSend;
-import jakarta.validation.constraints.*;
-import jakarta.ws.rs.*;
 import jakarta.ws.rs.BadRequestException;
 import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
 import jakarta.ws.rs.NotFoundException;
 import jakarta.ws.rs.POST;
+import jakarta.ws.rs.PUT;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import java.net.URI;
@@ -76,6 +78,9 @@ public class WebhooksResource extends AbstractAdminResource {
     webhook.setCreatedAt(w.getCreatedAt());
     webhook.setRealm(w.getRealm().getName());
     webhook.setEventTypes(w.getEventTypes());
+    webhook.setAlgorithm(w.getAlgorithm());
+    webhook.setAuthType(w.getAuthType());
+    webhook.setAudience(w.getAudience());
     // no secret
     return webhook;
   }
@@ -302,10 +307,21 @@ public class WebhooksResource extends AbstractAdminResource {
     if (rep.getSecret() != null && !"".equals(rep.getSecret())) {
       w.setSecret(rep.getSecret());
     }
+    String authType =
+        (rep.getAuthType() != null && !"".equals(rep.getAuthType()))
+            ? rep.getAuthType().toLowerCase()
+            : WebhookModel.AUTH_TYPE_HMAC;
+    w.setAuthType(authType);
     if (rep.getAlgorithm() != null && !"".equals(rep.getAlgorithm())) {
       w.setAlgorithm(rep.getAlgorithm());
     } else {
-      w.setAlgorithm("HmacSHA256");
+      w.setAlgorithm(
+          WebhookModel.AUTH_TYPE_BEARER.equals(authType)
+              ? WebhookModel.DEFAULT_BEARER_ALGORITHM
+              : WebhookModel.DEFAULT_HMAC_ALGORITHM);
+    }
+    if (rep.getAudience() != null && !"".equals(rep.getAudience())) {
+      w.setAudience(rep.getAudience());
     }
   }
 

--- a/src/main/java/io/phasetwo/keycloak/resources/WebhooksResource.java
+++ b/src/main/java/io/phasetwo/keycloak/resources/WebhooksResource.java
@@ -307,18 +307,23 @@ public class WebhooksResource extends AbstractAdminResource {
     if (rep.getSecret() != null && !"".equals(rep.getSecret())) {
       w.setSecret(rep.getSecret());
     }
-    String authType =
-        (rep.getAuthType() != null && !"".equals(rep.getAuthType()))
-            ? rep.getAuthType().toLowerCase()
-            : WebhookModel.AUTH_TYPE_HMAC;
+    // Authentication is one of: none, hmac, or bearer (JWT). When not specified, preserve the
+    // historical behavior: a secret implies HMAC signing, otherwise the webhook is unauthenticated.
+    String authType;
+    if (rep.getAuthType() != null && !"".equals(rep.getAuthType())) {
+      authType = rep.getAuthType().toLowerCase();
+    } else if (rep.getSecret() != null && !"".equals(rep.getSecret())) {
+      authType = WebhookModel.AUTH_TYPE_HMAC;
+    } else {
+      authType = WebhookModel.AUTH_TYPE_NONE;
+    }
     w.setAuthType(authType);
     if (rep.getAlgorithm() != null && !"".equals(rep.getAlgorithm())) {
       w.setAlgorithm(rep.getAlgorithm());
-    } else {
-      w.setAlgorithm(
-          WebhookModel.AUTH_TYPE_BEARER.equals(authType)
-              ? WebhookModel.DEFAULT_BEARER_ALGORITHM
-              : WebhookModel.DEFAULT_HMAC_ALGORITHM);
+    } else if (WebhookModel.AUTH_TYPE_BEARER.equals(authType)) {
+      w.setAlgorithm(WebhookModel.DEFAULT_BEARER_ALGORITHM);
+    } else if (WebhookModel.AUTH_TYPE_HMAC.equals(authType)) {
+      w.setAlgorithm(WebhookModel.DEFAULT_HMAC_ALGORITHM);
     }
     if (rep.getAudience() != null && !"".equals(rep.getAudience())) {
       w.setAudience(rep.getAudience());

--- a/src/main/resources/META-INF/jpa-changelog-events-20260706.xml
+++ b/src/main/resources/META-INF/jpa-changelog-events-20260706.xml
@@ -1,0 +1,14 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
+
+  <!-- webhook authentication type (hmac|bearer) and JWT audience for bearer auth -->
+  <changeSet author="xgp" id="202607061200-1">
+    <addColumn tableName="WEBHOOK">
+      <column name="AUTH_TYPE" type="VARCHAR(36)"/>
+    </addColumn>
+    <addColumn tableName="WEBHOOK">
+      <column name="AUDIENCE" type="VARCHAR(255)"/>
+    </addColumn>
+  </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/META-INF/jpa-changelog-events-main.xml
+++ b/src/main/resources/META-INF/jpa-changelog-events-main.xml
@@ -4,5 +4,6 @@
   <include file="META-INF/jpa-changelog-events-20220311.xml"/>
   <include file="META-INF/jpa-changelog-events-20221113.xml"/>
   <include file="META-INF/jpa-changelog-events-20250112.xml"/>
-  
+  <include file="META-INF/jpa-changelog-events-20260706.xml"/>
+
 </databaseChangeLog>

--- a/src/test/java/io/phasetwo/keycloak/Helpers.java
+++ b/src/test/java/io/phasetwo/keycloak/Helpers.java
@@ -1,7 +1,7 @@
 package io.phasetwo.keycloak;
 
-import static org.hamcrest.CoreMatchers.*;
-import static org.hamcrest.MatcherAssert.*;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertNotNull;
 
 import com.google.common.collect.ImmutableList;
@@ -69,6 +69,37 @@ public class Helpers {
     rep.setEnabled(true);
     rep.setUrl(url);
     rep.setSecret(secret);
+    if (types == null) {
+      rep.setEventTypes(ImmutableSet.of("*"));
+    } else {
+      rep.setEventTypes(types);
+    }
+
+    LegacySimpleHttp.Response response =
+        LegacySimpleHttp.doPost(baseUrl, httpClient)
+            .auth(keycloak.tokenManager().getAccessTokenString())
+            .json(rep)
+            .asResponse();
+    assertThat(response.getStatus(), is(201));
+    assertNotNull(response.getFirstHeader("Location"));
+    String loc = response.getFirstHeader("Location");
+    String id = loc.substring(loc.lastIndexOf("/") + 1);
+    return id;
+  }
+
+  public static String createBearerWebhook(
+      Keycloak keycloak,
+      CloseableHttpClient httpClient,
+      String baseUrl,
+      String url,
+      String audience,
+      Set<String> types)
+      throws Exception {
+    WebhookRepresentation rep = new WebhookRepresentation();
+    rep.setEnabled(true);
+    rep.setUrl(url);
+    rep.setAuthType("bearer");
+    rep.setAudience(audience);
     if (types == null) {
       rep.setEventTypes(ImmutableSet.of("*"));
     } else {

--- a/src/test/java/io/phasetwo/keycloak/Helpers.java
+++ b/src/test/java/io/phasetwo/keycloak/Helpers.java
@@ -118,6 +118,35 @@ public class Helpers {
     return id;
   }
 
+  public static String createUnauthenticatedWebhook(
+      Keycloak keycloak,
+      CloseableHttpClient httpClient,
+      String baseUrl,
+      String url,
+      Set<String> types)
+      throws Exception {
+    WebhookRepresentation rep = new WebhookRepresentation();
+    rep.setEnabled(true);
+    rep.setUrl(url);
+    rep.setAuthType("none");
+    if (types == null) {
+      rep.setEventTypes(ImmutableSet.of("*"));
+    } else {
+      rep.setEventTypes(types);
+    }
+
+    LegacySimpleHttp.Response response =
+        LegacySimpleHttp.doPost(baseUrl, httpClient)
+            .auth(keycloak.tokenManager().getAccessTokenString())
+            .json(rep)
+            .asResponse();
+    assertThat(response.getStatus(), is(201));
+    assertNotNull(response.getFirstHeader("Location"));
+    String loc = response.getFirstHeader("Location");
+    String id = loc.substring(loc.lastIndexOf("/") + 1);
+    return id;
+  }
+
   public static void removeWebhook(
       Keycloak keycloak, CloseableHttpClient httpClient, String baseUrl, String webhookId)
       throws Exception {

--- a/src/test/java/io/phasetwo/keycloak/events/WebhookSenderEventListenerProviderTest.java
+++ b/src/test/java/io/phasetwo/keycloak/events/WebhookSenderEventListenerProviderTest.java
@@ -1,9 +1,15 @@
 package io.phasetwo.keycloak.events;
 
+import static io.phasetwo.keycloak.Helpers.createBearerWebhook;
 import static io.phasetwo.keycloak.Helpers.createWebhook;
 import static io.phasetwo.keycloak.Helpers.removeWebhook;
-import static org.hamcrest.CoreMatchers.*;
-import static org.hamcrest.MatcherAssert.*;
+import static org.hamcrest.CoreMatchers.endsWith;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.startsWith;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -12,6 +18,7 @@ import com.google.common.collect.ImmutableSet;
 import io.phasetwo.keycloak.representation.ExtendedAdminEvent;
 import io.phasetwo.keycloak.resources.AbstractResourceTest;
 import jakarta.ws.rs.core.Response;
+import java.security.PublicKey;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
@@ -22,13 +29,21 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.junit.jupiter.api.Test;
 import org.keycloak.OAuth2Constants;
+import org.keycloak.TokenVerifier;
 import org.keycloak.admin.client.Keycloak;
 import org.keycloak.admin.client.KeycloakBuilder;
 import org.keycloak.admin.client.resource.RealmResource;
+import org.keycloak.broker.provider.util.LegacySimpleHttp;
+import org.keycloak.jose.jwk.JSONWebKeySet;
+import org.keycloak.jose.jwk.JWK;
+import org.keycloak.jose.jwk.JWKParser;
+import org.keycloak.jose.jws.JWSInput;
+import org.keycloak.representations.JsonWebToken;
 import org.keycloak.representations.idm.ClientRepresentation;
 import org.keycloak.representations.idm.RealmRepresentation;
 import org.keycloak.representations.idm.RoleRepresentation;
 import org.keycloak.representations.idm.UserRepresentation;
+import org.keycloak.util.JsonSerialization;
 
 @JBossLog
 public class WebhookSenderEventListenerProviderTest extends AbstractResourceTest {
@@ -162,6 +177,91 @@ public class WebhookSenderEventListenerProviderTest extends AbstractResourceTest
       bestEffortDeleteUser(realm, userId);
       bestEffortRemoveWebhook(keycloak, httpClient, webhookUrl(REALM), webhookId);
     }
+  }
+
+  @Test
+  public void testWebhookBearerJwtAuth() throws Exception {
+    // Configure
+    RealmResource realm = keycloak.realm(REALM);
+    RealmRepresentation realmRepresentation = realm.toRepresentation();
+    realmRepresentation.setEventsEnabled(true);
+    realmRepresentation.setAdminEventsEnabled(true);
+    realmRepresentation.setAdminEventsDetailsEnabled(true);
+    realmRepresentation.setEventsListeners(Arrays.asList("ext-event-webhook"));
+    realm.update(realmRepresentation);
+
+    AtomicReference<String> body = new AtomicReference<String>();
+    AtomicReference<String> authHeader = new AtomicReference<String>();
+    int port = WEBHOOK_SERVER_PORT;
+    String audience = "https://receiver.example.com";
+    String webhookId =
+        createBearerWebhook(
+            keycloak,
+            httpClient,
+            webhookUrl(REALM),
+            "http://host.testcontainers.internal:" + port + "/webhook",
+            audience,
+            ImmutableSet.of("admin.*"));
+
+    Server server = newWebhookServer(port, body, authHeader);
+    server.start();
+    Thread.sleep(1000l);
+
+    String userId = null;
+    try {
+      // cause an event to be sent
+      UserRepresentation userRepresentation = new UserRepresentation();
+      userRepresentation.setUsername("jwtuser");
+      Response userResponse = realm.users().create(userRepresentation);
+      assertThat(userResponse.getStatus(), is(201));
+
+      String payload = awaitBody(body, "admin.USER-CREATE on master (bearer)");
+      ExtendedAdminEvent event = parseEvent(payload);
+      assertThat(event.getType(), equalTo("admin.USER-CREATE"));
+
+      // the payload is authenticated via an Authorization: Bearer JWT, not a shared secret
+      String auth = authHeader.get();
+      assertThat(auth, notNullValue());
+      assertThat(auth, startsWith("Bearer "));
+      String jwt = auth.substring("Bearer ".length());
+
+      // verify the JWT signature against the realm JWKS and validate its claims
+      JsonWebToken token = verifyJwtAgainstRealmJwks(jwt, REALM);
+      assertThat(token.getIssuer(), endsWith("/realms/" + REALM));
+      assertThat(Arrays.asList(token.getAudience()), hasItem(audience));
+      assertThat(token.getExp() > System.currentTimeMillis() / 1000L, is(true));
+      // the request_body_sha256 claim binds the token to this exact payload
+      String bodyHash = (String) token.getOtherClaims().get("request_body_sha256");
+      assertThat(bodyHash, equalTo(WebhookJwtSigner.sha256Hex(payload)));
+
+      List<UserRepresentation> users = realm.users().search("jwtuser");
+      assertThat(users.size(), is(1));
+      userId = users.get(0).getId();
+    } finally {
+      server.stop();
+      bestEffortDeleteUser(realm, userId);
+      bestEffortRemoveWebhook(keycloak, httpClient, webhookUrl(REALM), webhookId);
+    }
+  }
+
+  /** Verify a compact JWS against the realm's published JWKS and return the parsed token. */
+  private JsonWebToken verifyJwtAgainstRealmJwks(String jwt, String realmName) throws Exception {
+    String certsUrl = getAuthUrl() + "/realms/" + realmName + "/protocol/openid-connect/certs";
+    String certs = LegacySimpleHttp.doGet(certsUrl, httpClient).asString();
+    JSONWebKeySet jwks = JsonSerialization.readValue(certs, JSONWebKeySet.class);
+    String kid = new JWSInput(jwt).getHeader().getKeyId();
+    PublicKey publicKey = null;
+    for (JWK jwk : jwks.getKeys()) {
+      if (kid.equals(jwk.getKeyId())) {
+        publicKey = JWKParser.create(jwk).toPublicKey();
+        break;
+      }
+    }
+    assertThat("no JWKS key matching kid " + kid, publicKey, notNullValue());
+    TokenVerifier<JsonWebToken> verifier =
+        TokenVerifier.create(jwt, JsonWebToken.class).publicKey(publicKey);
+    verifier.verify(); // throws on bad signature
+    return verifier.getToken();
   }
 
   @Test
@@ -420,6 +520,11 @@ public class WebhookSenderEventListenerProviderTest extends AbstractResourceTest
   }
 
   private static Server newWebhookServer(int port, AtomicReference<String> body) {
+    return newWebhookServer(port, body, null);
+  }
+
+  private static Server newWebhookServer(
+      int port, AtomicReference<String> body, AtomicReference<String> authHeader) {
     Server server = new Server(port);
     server
         .router()
@@ -428,6 +533,9 @@ public class WebhookSenderEventListenerProviderTest extends AbstractResourceTest
             (request, response) -> {
               String r = request.body();
               log.infof("%s", r);
+              if (authHeader != null) {
+                authHeader.set(request.header("Authorization"));
+              }
               body.set(r);
               response.body("OK");
               response.status(202);

--- a/src/test/java/io/phasetwo/keycloak/events/WebhookSenderEventListenerProviderTest.java
+++ b/src/test/java/io/phasetwo/keycloak/events/WebhookSenderEventListenerProviderTest.java
@@ -1,6 +1,7 @@
 package io.phasetwo.keycloak.events;
 
 import static io.phasetwo.keycloak.Helpers.createBearerWebhook;
+import static io.phasetwo.keycloak.Helpers.createUnauthenticatedWebhook;
 import static io.phasetwo.keycloak.Helpers.createWebhook;
 import static io.phasetwo.keycloak.Helpers.removeWebhook;
 import static org.hamcrest.CoreMatchers.endsWith;
@@ -8,6 +9,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.CoreMatchers.startsWith;
 import static org.hamcrest.MatcherAssert.assertThat;
 
@@ -21,7 +23,9 @@ import jakarta.ws.rs.core.Response;
 import java.security.PublicKey;
 import java.time.Duration;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import lombok.extern.jbosslog.JBossLog;
@@ -191,7 +195,7 @@ public class WebhookSenderEventListenerProviderTest extends AbstractResourceTest
     realm.update(realmRepresentation);
 
     AtomicReference<String> body = new AtomicReference<String>();
-    AtomicReference<String> authHeader = new AtomicReference<String>();
+    AtomicReference<Map<String, String>> headers = new AtomicReference<Map<String, String>>();
     int port = WEBHOOK_SERVER_PORT;
     String audience = "https://receiver.example.com";
     String webhookId =
@@ -203,7 +207,7 @@ public class WebhookSenderEventListenerProviderTest extends AbstractResourceTest
             audience,
             ImmutableSet.of("admin.*"));
 
-    Server server = newWebhookServer(port, body, authHeader);
+    Server server = newWebhookServer(port, body, headers);
     server.start();
     Thread.sleep(1000l);
 
@@ -220,7 +224,7 @@ public class WebhookSenderEventListenerProviderTest extends AbstractResourceTest
       assertThat(event.getType(), equalTo("admin.USER-CREATE"));
 
       // the payload is authenticated via an Authorization: Bearer JWT, not a shared secret
-      String auth = authHeader.get();
+      String auth = headers.get().get("Authorization");
       assertThat(auth, notNullValue());
       assertThat(auth, startsWith("Bearer "));
       String jwt = auth.substring("Bearer ".length());
@@ -235,6 +239,58 @@ public class WebhookSenderEventListenerProviderTest extends AbstractResourceTest
       assertThat(bodyHash, equalTo(WebhookJwtSigner.sha256Hex(payload)));
 
       List<UserRepresentation> users = realm.users().search("jwtuser");
+      assertThat(users.size(), is(1));
+      userId = users.get(0).getId();
+    } finally {
+      server.stop();
+      bestEffortDeleteUser(realm, userId);
+      bestEffortRemoveWebhook(keycloak, httpClient, webhookUrl(REALM), webhookId);
+    }
+  }
+
+  @Test
+  public void testWebhookNoneAuth() throws Exception {
+    // Configure
+    RealmResource realm = keycloak.realm(REALM);
+    RealmRepresentation realmRepresentation = realm.toRepresentation();
+    realmRepresentation.setEventsEnabled(true);
+    realmRepresentation.setAdminEventsEnabled(true);
+    realmRepresentation.setAdminEventsDetailsEnabled(true);
+    realmRepresentation.setEventsListeners(Arrays.asList("ext-event-webhook"));
+    realm.update(realmRepresentation);
+
+    AtomicReference<String> body = new AtomicReference<String>();
+    AtomicReference<Map<String, String>> headers = new AtomicReference<Map<String, String>>();
+    int port = WEBHOOK_SERVER_PORT;
+    String webhookId =
+        createUnauthenticatedWebhook(
+            keycloak,
+            httpClient,
+            webhookUrl(REALM),
+            "http://host.testcontainers.internal:" + port + "/webhook",
+            ImmutableSet.of("admin.*"));
+
+    Server server = newWebhookServer(port, body, headers);
+    server.start();
+    Thread.sleep(1000l);
+
+    String userId = null;
+    try {
+      // cause an event to be sent
+      UserRepresentation userRepresentation = new UserRepresentation();
+      userRepresentation.setUsername("noneuser");
+      Response userResponse = realm.users().create(userRepresentation);
+      assertThat(userResponse.getStatus(), is(201));
+
+      String payload = awaitBody(body, "admin.USER-CREATE on master (none)");
+      ExtendedAdminEvent event = parseEvent(payload);
+      assertThat(event.getType(), equalTo("admin.USER-CREATE"));
+
+      // an unauthenticated webhook sends neither a signature nor a bearer token
+      assertThat(headers.get().get("Authorization"), nullValue());
+      assertThat(headers.get().get("X-Keycloak-Signature"), nullValue());
+
+      List<UserRepresentation> users = realm.users().search("noneuser");
       assertThat(users.size(), is(1));
       userId = users.get(0).getId();
     } finally {
@@ -523,8 +579,13 @@ public class WebhookSenderEventListenerProviderTest extends AbstractResourceTest
     return newWebhookServer(port, body, null);
   }
 
+  /**
+   * Webhook server that, in addition to capturing the body, records the authentication-related
+   * request headers ({@code Authorization} and {@code X-Keycloak-Signature}) into {@code headers}
+   * when provided. Missing headers are stored as {@code null}.
+   */
   private static Server newWebhookServer(
-      int port, AtomicReference<String> body, AtomicReference<String> authHeader) {
+      int port, AtomicReference<String> body, AtomicReference<Map<String, String>> headers) {
     Server server = new Server(port);
     server
         .router()
@@ -533,8 +594,11 @@ public class WebhookSenderEventListenerProviderTest extends AbstractResourceTest
             (request, response) -> {
               String r = request.body();
               log.infof("%s", r);
-              if (authHeader != null) {
-                authHeader.set(request.header("Authorization"));
+              if (headers != null) {
+                Map<String, String> captured = new HashMap<>();
+                captured.put("Authorization", request.header("Authorization"));
+                captured.put("X-Keycloak-Signature", request.header("X-Keycloak-Signature"));
+                headers.set(captured);
               }
               body.set(r);
               response.body("OK");


### PR DESCRIPTION
## Summary

Webhook payloads today can only be authenticated with a keyed-HMAC shared secret sent in the `X-Keycloak-Signature` header. This PR adds an alternative: signing each payload with a short-lived JWT using the realm's active signing key, sent as an `Authorization: Bearer` token. A receiver can verify it against the realm's JWKS (issuer + audience) — the same keys used for access tokens — without a shared secret to exchange or store.

This was requested by a customer who wanted to protect a webhook with a Keycloak-issued token and configure the receiver with just `{ jwks_uri, issuer, audience }`.

### What changed

- **Model/schema.** New `authType` (`hmac` | `bearer`) and `audience` fields on the webhook model, JPA entity, representation, and REST mapping, plus a Liquibase changeset (`jpa-changelog-events-20260706.xml`) adding the two columns. Defaults keep existing webhooks on HMAC — **no behavior change** for current webhooks.
- **`WebhookJwtSigner`.** Mints a JWT (default `RS256`, configurable via `algorithm`) with `iss`/`aud`/`iat`/`exp`, a `jti`, and a `request_body_sha256` claim that binds the token to the exact payload (prevents replay against a different body).
- **Send path.** Tokens are minted **per send attempt** on the background scheduler thread via a fresh transaction (signing needs the realm's active key, and the request session is gone by send time). Because each retry re-mints, tokens can be short-lived (default 300s, override with `WEBHOOK_JWT_LIFESPAN_SECONDS`) without breaking the retry/backoff window.
- **Issuer resolution.** Realm frontend URL → `KC_HOSTNAME` → the request base URI captured at construction (background dispatch has no request context).
- **System catch-all.** Supports bearer auth via `WEBHOOK_AUTH_TYPE` / `WEBHOOK_AUDIENCE` env vars.
- **Docs.** README section on authenticating the payload (HMAC vs bearer), the receiver-side config, and the token claims.

### Receiver configuration

```json
{
  "jwks_uri": "https://keycloak.example.com/realms/my-realm/protocol/openid-connect/certs",
  "issuer": "https://keycloak.example.com/realms/my-realm",
  "audience": "https://receiver.example.com"
}
```

## Test plan

- [x] `WebhookSenderEventListenerProviderTest#testWebhookBearerJwtAuth` — triggers an event on a bearer webhook, captures the `Authorization` header, **verifies the JWT signature against the realm JWKS**, and asserts `iss`, `aud`, `exp`, and the `request_body_sha256` claim match.
- [x] Full `WebhookSenderEventListenerProviderTest` class green (6/6), confirming the existing HMAC path is unchanged.

## Notes

- For the emitted issuer to match the realm's real token issuer in production, configure the realm frontend URL or `KC_HOSTNAME` (webhooks are dispatched on a background thread with no request URI). Documented in the README.
